### PR TITLE
Avoid NPEs when testing

### DIFF
--- a/src/main/java/frc/robot/subsystems/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/VisionSubsystem.java
@@ -314,7 +314,7 @@ public class VisionSubsystem extends SubsystemBase {
       } else if (cameraData.megaTag2.poseEstimate.pose.getY() <= 0) {
         error = "Pose has too little Y";
       }
-      if (error.length() == 0) {
+      if (sd != null && error.length() == 0) {
         double distanceError = sd.getPose().getTranslation()
             .getDistance(cameraData.megaTag2.poseEstimate.pose.getTranslation());
 


### PR DESCRIPTION
Corner case with vision and no swerve.